### PR TITLE
make disable setting pickerStyle on previous iOS versions

### DIFF
--- a/Pickers/ActionSheetDatePicker.m
+++ b/Pickers/ActionSheetDatePicker.m
@@ -164,7 +164,10 @@
     datePicker.calendar = self.calendar;
     datePicker.timeZone = self.timeZone;
     datePicker.locale = self.locale;
-    datePicker.preferredDatePickerStyle = UIDatePickerStyleWheels;
+    
+    if (@available(iOS 13.4, *)) {
+        datePicker.preferredDatePickerStyle = UIDatePickerStyleWheels;
+    }
 
     UIColor *textColor = [self.pickerTextAttributes valueForKey:NSForegroundColorAttributeName];
     if (textColor) {


### PR DESCRIPTION
-on previous iOS versions(<iOS14) the date picker crashes due to 'unrecognized selector'